### PR TITLE
added shim to typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
       "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
     },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
     "asn1.js": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
@@ -47,10 +52,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
-    },
-    "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
     },
     "bindings": {
       "version": "1.5.0",
@@ -89,6 +90,27 @@
         "evp_bytestokey": "^1.0.3",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "buffer-to-arraybuffer": {
@@ -140,10 +162,13 @@
         "sha.js": "^2.4.8"
       }
     },
-    "crypto-js": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -164,6 +189,15 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
+      }
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "dom-walk": {
@@ -226,6 +260,15 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
+      }
+    },
     "eth-lib": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
@@ -264,6 +307,45 @@
         "secp256k1": "^3.0.1"
       }
     },
+    "ethers": {
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.32.tgz",
+      "integrity": "sha512-r0k2tBNF6MYEsvwmINeP3VPppD/7eAZyiOk/ifDDawXGCKqr3iEQkPq6OZSDVD+4Jie38WPteS9thXzpn2+A5Q==",
+      "requires": {
+        "@types/node": "^10.3.2",
+        "aes-js": "3.0.0",
+        "bn.js": "^4.4.0",
+        "elliptic": "6.3.3",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
+    },
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -288,6 +370,11 @@
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
       }
+    },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -366,6 +453,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -406,6 +501,16 @@
       "requires": {
         "has-symbols": "^1.0.0"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "jsontokens": {
       "version": "2.0.2",
@@ -481,6 +586,11 @@
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
@@ -529,10 +639,27 @@
         "string.prototype.trim": "^1.1.2"
       }
     },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
       "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "query-string": {
       "version": "5.1.1",
@@ -543,6 +670,11 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
+    },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -556,6 +688,11 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
       "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -575,10 +712,49 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "rxjs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "scrypt": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
+      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.0.8"
+      }
+    },
+    "scrypt-js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+    },
+    "scrypt.js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
+      "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
+      "requires": {
+        "scrypt": "^6.0.2",
+        "scryptsy": "^1.2.1"
+      }
+    },
+    "scryptsy": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
+      "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+      "requires": {
+        "pbkdf2": "^3.0.3"
+      }
     },
     "secp256k1": {
       "version": "3.7.1",
@@ -594,6 +770,11 @@
         "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "setimmediate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -647,11 +828,33 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typescript": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
       "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "url-set-query": {
       "version": "1.0.0",
@@ -663,16 +866,246 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
       "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
     },
+    "uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+    },
     "web3": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
-      "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.55.tgz",
+      "integrity": "sha512-yJpwy4IUA3T/F9hWzYQVn0GbJCrAaZ0KTIO3iuqkhaYH0Y09KV7k4GzFi4hN7hT4cFTj4yIKaeVCwQ5kzvi2Vg==",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2-cookies": "^1.1.0",
-        "xmlhttprequest": "*"
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "web3-core": "1.0.0-beta.55",
+        "web3-eth": "1.0.0-beta.55",
+        "web3-eth-personal": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-shh": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-core": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.55.tgz",
+      "integrity": "sha512-AMMp7TLEtE7u8IJAu/THrRhBTZyZzeo7Y6GiWYNwb5+KStC9hIGLr9cI1KX9R6ZioTOLRHrqT7awDhnJ1ku2mg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
+        "@types/node": "^10.12.18",
+        "lodash": "^4.17.11",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.55.tgz",
+      "integrity": "sha512-suj9Xy/lIqajaYLJTEjr2rlFgu6hGYwChHmf8+qNrC2luZA6kirTamtB9VThWMxbywx7p0bqQFjW6zXogAgWhg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.55",
+        "web3-eth-iban": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-core-method": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.55.tgz",
+      "integrity": "sha512-w1cW/s2ji9qGELHk2uMJCn1ooay0JJLVoPD1nvmsW6OTRWcVjxa62nJrFQhe6P5lEb83Xk9oHgmCxZoVUHibOw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11",
+        "rxjs": "^6.4.0",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-core-subscriptions": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.55.tgz",
+      "integrity": "sha512-pb3oQbUzK7IoyXwag8TYInQddg0rr7BHxKc+Pbs/92hVNQ5ps4iGMVJKezdrjlQ1IJEEUiDIglXl4LZ1hIuMkw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eventemitter3": "^3.1.0",
+        "lodash": "^4.17.11"
+      }
+    },
+    "web3-eth": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.55.tgz",
+      "integrity": "sha512-F3zJ9I1gOgQdNGfi2Dy2lmj6OqCMJoRN01XHhQZagq0HY1JYMfObtfMi5E3L+qsegsSddHbqp4YY57tKx6uxpA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "ethereumjs-tx": "^1.3.7",
+        "rxjs": "^6.4.0",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-eth-abi": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-eth-contract": "1.0.0-beta.55",
+        "web3-eth-ens": "1.0.0-beta.55",
+        "web3-eth-iban": "1.0.0-beta.55",
+        "web3-eth-personal": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.55.tgz",
+      "integrity": "sha512-3h1xnm/vYmKUXTOYAOP0OsB5uijQV76pNNRGKOB6Dq6GR1pbcbD3WrB/4I643YA8l91t5FRzFzUiA3S77R2iqw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "ethers": "^4.0.27",
+        "lodash": "^4.17.11",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.55.tgz",
+      "integrity": "sha512-VfzvwpSDHXqRVelIxsBVhgbV9BkFvhJ/q+bKhnVUUXV0JAhMK/7uC92TsqKk4EBYuqpHyZ1jjqrL4n03fMU7zw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "browserify-cipher": "^1.0.1",
+        "eth-lib": "0.2.8",
+        "lodash": "^4.17.11",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "scrypt.js": "0.3.0",
+        "uuid": "3.3.2",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.55.tgz",
+      "integrity": "sha512-v6oB1wfH039/A5sTb4ZTKX++fcBTHEkuQGpq50ATIDoxP/UTz2+6S+iL+3sCJTsByPw2/Bni/HM7NmLkXqzg/Q==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-eth-abi": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.55.tgz",
+      "integrity": "sha512-jEL17coO0FJXb7KYq4+7DhVXj0Rh+wHfZ86jOvFUvJsRaUHfqK2TlMatuhD2mbrmxpBYb6oMPnXVnNK9bnD5Rg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eth-ens-namehash": "2.0.8",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-eth-abi": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-eth-contract": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.55.tgz",
+      "integrity": "sha512-a2Fxsb5Mssa+jiXgjUdIzJipE0175IcQXJbZLpKft2+zeSJWNTbaa3PQD2vPPpIM4W789q06N+f9Zc0Fyls+1g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "bn.js": "4.11.8",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-eth-personal": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.55.tgz",
+      "integrity": "sha512-H0mahLQx6Oj7lpgTamKAswr3rHChRUZijeWAar2Hj7BABQlLRKwx8n09nYhxggvvLYQNQS90JjvQue7rAo2LQQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-net": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.55.tgz",
+      "integrity": "sha512-do2WY8+/GArJSWX7k/zZ7nBnV9Y3n6LhPYkwT3LeFqDzD515bKwlomaNC8hOaTc6UQyXIoPprYTK2FevL7jrZw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
+      }
+    },
+    "web3-providers": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.55.tgz",
+      "integrity": "sha512-MNifc7W+iF6rykpbDR1MuX152jshWdZXHAU9Dk0Ja2/23elhIs4nCWs7wOX9FHrKgdrQbscPoq0uy+0aGzyWVQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11",
+        "url-parse": "1.4.4",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55",
+        "websocket": "^1.0.28",
+        "xhr2-cookies": "1.1.0"
+      }
+    },
+    "web3-shh": {
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.55.tgz",
+      "integrity": "sha512-lGP2HQ/1ThNnfoU8677aL48KsTx4Ht+2KQIn39dGpxVZqysQmovQIltbymVnAr4h8wofwcEz46iNHGa+PAyNzA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-utils": {
@@ -690,6 +1123,17 @@
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
         "utf8": "2.1.1"
+      }
+    },
+    "websocket": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+      "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.11.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
       }
     },
     "wrappy": {
@@ -747,6 +1191,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "alastria-id-lib",
   "version": "1.0.0",
   "description": "A library to interact with alastria-identity smart contracts",
-  "main": "src/index.ts",
+  "main": "src/index.js",
   "bin": {
-    "alastria-identity-lib": "src/index.ts"
+    "alastria-identity-lib": "src/index.js"
   },
-  "types": "src/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "postinstall": "tsc",
     "build": "tsc"

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+let library = require('../dist/index.js')
+
+module.exports.UserIdentity = library.UserIdentity
+module.exports.transactionFactory = library.transactionFactory

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,0 @@
-export {transactionFactory} from './factory/transactionFactory'
-export {UserIdentity} from './transactionProcess'


### PR DESCRIPTION
Declaring files that do not exist in the repo in the `package.json` file turns out to be a really bad idea when you are using it as a dependency directly from github.

I have added a shim to the typescript generated files that will always exist no matter what. At installation time, the npm script will run and compile the typescript so the shim target will exist. Does that make sense?