### PR TITLE
Support updated Node.js versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5243,37 +5243,6 @@
         "web3-net": "1.2.1"
       }
     },
-    "web3-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0.tgz",
-      "integrity": "sha512-zm0gdLXLk54ldwxxBMNPS62EuqHI2PaJohEGijTowacNS0BS2vEXdriNA8gp1+EplP2WgoHE0uRVmQIfpAyV+Q==",
-      "requires": {
-        "bn.js": "4.11.8",
-        "eth-lib": "0.2.7",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
-        "underscore": "1.9.1",
-        "utf8": "3.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-        },
-        "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        }
-      }
-    },
     "websocket": {
       "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
       "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,14 +30,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2785,7 +2777,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -3729,11 +3722,6 @@
       "requires": {
         "picomatch": "^2.0.4"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regexpp": {
       "version": "3.1.0",
@@ -5256,46 +5244,33 @@
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.55.tgz",
-      "integrity": "sha512-ASWqUi8gtWK02Tp8ZtcoAbHenMpQXNvHrakgzvqTNNZn26wgpv+Q4mdPi0KOR6ZgHFL8R/9b5BBoUTglS1WPpg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0.tgz",
+      "integrity": "sha512-zm0gdLXLk54ldwxxBMNPS62EuqHI2PaJohEGijTowacNS0BS2vEXdriNA8gp1+EplP2WgoHE0uRVmQIfpAyV+Q==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@types/bn.js": "^4.11.4",
-        "@types/node": "^10.12.18",
         "bn.js": "4.11.8",
-        "eth-lib": "0.2.8",
-        "ethjs-unit": "^0.1.6",
-        "lodash": "^4.17.11",
+        "eth-lib": "0.2.7",
+        "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "2.1.1"
+        "randomhex": "0.1.5",
+        "underscore": "1.9.1",
+        "utf8": "3.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
-        },
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
           }
-        },
-        "utf8": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -493,9 +493,9 @@
       "dev": true
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -1284,17 +1284,17 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "emoji-regex": {
@@ -5488,9 +5488,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yaeti": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -492,22 +492,6 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1271,16 +1255,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -2064,11 +2038,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2762,44 +2731,16 @@
       }
     },
     "keythereum": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-1.0.4.tgz",
-      "integrity": "sha512-c3gWM0nQ6x5TKAzTOA1yIqn73S8sP9+lR7mc7QS6t509g7C0/CukykxGA6+B+aXI6BIrlSwVh5muPv/I1lD9LA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/keythereum/-/keythereum-1.2.0.tgz",
+      "integrity": "sha512-u3XnjIruOmjIvJ4tH1Wdr2y0X8+z8BZTQ+dqJuDMyLvNWw6VnH9XKtt0yauSE+96Bq97h6CPm4w5LbW3i28x0g==",
       "requires": {
         "crypto-browserify": "3.12.0",
-        "keccak": "1.4.0",
-        "scrypt": "6.0.3",
-        "secp256k1": "3.5.0",
+        "keccak": "3.0.1",
+        "scrypt-js": "3.0.1",
+        "secp256k1": "4.0.2",
         "sjcl": "1.0.6",
         "uuid": "3.0.0"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "secp256k1": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
-          "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "bip66": "^1.1.3",
-            "bn.js": "^4.11.3",
-            "create-hash": "^1.1.2",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.2.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        }
       }
     },
     "keyv": {
@@ -3907,14 +3848,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "scrypt": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-      "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-      "requires": {
-        "nan": "^2.0.8"
-      }
     },
     "scrypt-js": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai-as-promised": "^7.1.1",
     "ethereumjs-tx": "^1.3.3",
     "jsontokens": "2.0.2",
-    "keythereum": "1.0.4",
+    "keythereum": "^1.2.0",
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "typescript": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "npm-run-all": "4.1.5",
     "rimraf": "2.6.3",
     "typescript": "3.5.2",
-    "web3": "1.2.1",
-    "web3-utils": "^1.0.0"
+    "web3": "1.2.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rimraf": "2.6.3",
     "typescript": "3.5.2",
     "web3": "1.2.1",
-    "web3-utils": "1.0.0-beta.55"
+    "web3-utils": "^1.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Documentation

## Description
- Update keythereum to 1.2.0 to allow npm to compile with node > 10. Fixes #134 
- Fix npm install problem when the alastria-identity repo is already cloned
- Delete web3-utils from package.json, not necessary
- Update some others needed dependencies. Fixes #140, #143