### PR TITLE
The encodedFunctionCall is modified so that the createAlastriaIdentit…

### DIFF
--- a/src/txFactory/identityManagerTransactionFactory.ts
+++ b/src/txFactory/identityManagerTransactionFactory.ts
@@ -5,7 +5,7 @@ import { AddressUtils } from '../utils/AddressUtils'
 /**
  * function delegateCall(address _destination, uint256 _value, bytes _data) public
  * @param web3 ethereum connection
- * @param _destination 
+ * @param _destination
  * @param _value
  * @param _data
  */
@@ -65,13 +65,13 @@ export function createAlastriaIdentity(web3, publicKey) {
 export function createAlastriaIdentityHash(web3, publicKeyHash) {
   const transaction = Object.assign({}, config.basicTransaction)
   transaction.gasLimit = 600000
-  const publicKeyCallData = web3.eth.abi.encodeFunctionCall(
-    config.contractsAbi.AlastriaPublicKeyRegistry.addPublicKey,
-    [publicKeyHash]
-  )
   transaction.data = web3.eth.abi.encodeFunctionCall(
-    config.contractsAbi.AlastriaIdentityManager.createAlastriaIdentity,
-    [publicKeyCallData]
+    {
+      name: 'createAlastriaIdentity',
+      type: 'function',
+      inputs: [{ type: 'bytes32', name: 'publicKeyHash' }]
+    },
+    [publicKeyHash]
   )
   transaction.to = config.alastriaIdentityManager
   return transaction


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation

## Description
The encodedFunctionCall is modified so that the createAlastriaIdentity smart contracts function is called correctly, as there are two functions with the same name and almost identical data types in the input parameter (bytes and bytes32).

The problem lies in the method overloading of createAlastriaIdentity and its input parameter. The old function received a bytes, while the new one accepts a bytes32. Therefore, it's necessary to specify the function's name and parameters along with their types in the library to ensure it calls the new function instead of the old one.